### PR TITLE
[1.x] Add support for setting badge count on iOS

### DIFF
--- a/src/Services/Larafirebase.php
+++ b/src/Services/Larafirebase.php
@@ -27,6 +27,8 @@ class Larafirebase
 
     private $fromRaw;
 
+    private $iosBadgeCount;
+
     const API_URI = 'https://fcm.googleapis.com/fcm/send';
 
     public function withTitle($title)
@@ -92,6 +94,13 @@ class Larafirebase
         return $this;
     }
 
+    public function withIosBadgeCount($iosBadgeCount)
+    {
+        $this->iosBadgeCount = $iosBadgeCount;
+
+        return $this;
+    }
+
     public function sendNotification($tokens)
     {
         $fields = array(
@@ -106,6 +115,15 @@ class Larafirebase
             'data' => $this->additionalData,
             'priority' => $this->priority
         );
+        if (isset($iosBadgeCount)) {
+            $fields['apns'] = [
+                'payload' => [
+                    'aps' => [
+                        'badge' => $iosBadgeCount
+                    ]
+                ]
+            ];
+        }
         return $this->callApi($fields);
     }
 

--- a/src/Services/Larafirebase.php
+++ b/src/Services/Larafirebase.php
@@ -110,6 +110,22 @@ class Larafirebase
         return $this;
     }
 
+    public function sendBackgroundUpdate($tokens)
+    {
+        $fields = array(
+            'registration_ids' => $this->validateToken($tokens),
+            'notification' => ($this->fromArray) ? $this->fromArray : [
+                'content_available' => true
+            ],
+            'data' => $this->additionalData,
+            'priority' => $this->priority
+        );
+        if (isset($this->badgeCount)) {
+            $fields['notification']['badge'] = $this->badgeCount;
+        }
+        return $this->callApi($fields);
+    }
+
     public function sendNotification($tokens)
     {
         $fields = array(

--- a/src/Services/Larafirebase.php
+++ b/src/Services/Larafirebase.php
@@ -29,6 +29,8 @@ class Larafirebase
 
     private $badgeCount;
 
+    private $contentAvailable;
+
     const API_URI = 'https://fcm.googleapis.com/fcm/send';
 
     public function withTitle($title)
@@ -101,6 +103,13 @@ class Larafirebase
         return $this;
     }
 
+    public function withContentAvailable($contentAvailable)
+    {
+        $this->contentAvailable = $contentAvailable;
+
+        return $this;
+    }
+
     public function sendNotification($tokens)
     {
         $fields = array(
@@ -117,6 +126,9 @@ class Larafirebase
         );
         if (isset($this->badgeCount)) {
             $fields['notification']['badge'] = $this->badgeCount;
+        }
+        if (isset($this->contentAvailable)) {
+            $fields['notification']['content_available'] = $this->contentAvailable;
         }
         return $this->callApi($fields);
     }

--- a/src/Services/Larafirebase.php
+++ b/src/Services/Larafirebase.php
@@ -27,7 +27,7 @@ class Larafirebase
 
     private $fromRaw;
 
-    private $iosBadgeCount;
+    private $badgeCount;
 
     const API_URI = 'https://fcm.googleapis.com/fcm/send';
 
@@ -94,9 +94,9 @@ class Larafirebase
         return $this;
     }
 
-    public function withIosBadgeCount($iosBadgeCount)
+    public function withBadgeCount($iosBadgeCount)
     {
-        $this->iosBadgeCount = $iosBadgeCount;
+        $this->badgeCount = $badgeCount;
 
         return $this;
     }
@@ -115,14 +115,8 @@ class Larafirebase
             'data' => $this->additionalData,
             'priority' => $this->priority
         );
-        if (isset($this->iosBadgeCount)) {
-            $fields['apns'] = [
-                'payload' => [
-                    'aps' => [
-                        'badge' => $this->iosBadgeCount
-                    ]
-                ]
-            ];
+        if (isset($this->badgeCount)) {
+            $fields['notification']['badge'] = $this->badgeCount;
         }
         return $this->callApi($fields);
     }

--- a/src/Services/Larafirebase.php
+++ b/src/Services/Larafirebase.php
@@ -115,7 +115,7 @@ class Larafirebase
             'data' => $this->additionalData,
             'priority' => $this->priority
         );
-        if (isset($iosBadgeCount)) {
+        if (isset($this->iosBadgeCount)) {
             $fields['apns'] = [
                 'payload' => [
                     'aps' => [

--- a/src/Services/Larafirebase.php
+++ b/src/Services/Larafirebase.php
@@ -119,7 +119,7 @@ class Larafirebase
             $fields['apns'] = [
                 'payload' => [
                     'aps' => [
-                        'badge' => $iosBadgeCount
+                        'badge' => $this->iosBadgeCount
                     ]
                 ]
             ];

--- a/src/Services/Larafirebase.php
+++ b/src/Services/Larafirebase.php
@@ -94,7 +94,7 @@ class Larafirebase
         return $this;
     }
 
-    public function withBadgeCount($iosBadgeCount)
+    public function withBadgeCount($badgeCount)
     {
         $this->badgeCount = $badgeCount;
 


### PR DESCRIPTION
This PR allows the user to attach a badge count, in other words, the number of unread notifications on an app icon. It also allows sending background updates through Firebase, e.g. to wake up the app from a sleeping state.